### PR TITLE
Use num_cpus instead of nightly feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "hlua",
  "ipaddress",
  "message-io",
+ "num_cpus",
  "serde",
  "tui",
 ]
@@ -518,6 +519,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crossbeam-channel = "0.5.0"
 crossbeam = "0.8.0"
 tui = { version = "0.14", default-features = false, features = ['crossterm'] }
 chrono = "0.4.19"
+num_cpus = "1.14.0"
 
 [patch.crates-io]
 hlua = { git = "https://github.com/ray33ee/hlua" }

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Think of a good way to select scripts while running?
   - At the moment the user can just modify the script (thge one chosen when the application started) since executing will load the modified scriptc
 
+### Changed
+- Replaced nightly code with crate `num_cpus`
+
 ## [0.2.18] - 2021-03-07
 
 ### Added

--- a/readme.md
+++ b/readme.md
@@ -89,12 +89,10 @@ This functions returns a string, which can be used to show a message indicating 
 To build, simply download and unzip the [repo](https://github.com/ray33ee/Project-Midas/archive/master.zip), navigate to the unzipped repo and execute the following command
 
 ```shell
-cargo +nightly build --release
+cargo build --release
 ```
 
 Then navigate to the `target/release` folder and execute `midas` with the command options as stated above
-
-We also use the [available_concurrency](https://doc.rust-lang.org/std/thread/fn.available_concurrency.html) function which is currently nightly only.
 
 ## Native binaries
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(available_concurrency)]
-
 mod host;
 mod participant;
 mod messages;
@@ -121,7 +119,7 @@ fn main() {
                 number.parse::<usize>().unwrap()
             }
             else {
-                thread::available_concurrency().unwrap().get()
+                num_cpus::get()
             };
 
             let participant_name = participant_matches.unwrap().value_of("participant name").unwrap();


### PR DESCRIPTION
With the use of `num_cpus` it's possible to drop the nightly requirement.